### PR TITLE
Remove refs to hyperlinks

### DIFF
--- a/newsView.yaml
+++ b/newsView.yaml
@@ -77,21 +77,21 @@ images:
     caption:
 content:
   - paragraph: >-
-      "The ICDC team released v.3.39.4 on October 25, 2022. This release expands the functionality of JBrowse by enabling analysis across
+      The ICDC team released v.3.39.4 on October 25, 2022. This release expands the functionality of JBrowse by enabling analysis across
       multiple sequence files, improves system performance via integration of Elasticsearch, and enables identification of data model properties actively displayed in the user interface. Addtionally, there are several upgrades to the Data Model Explorer, including
-      the support for download of controlled vocabularies in machine-readable TSV and JSON formats, the support for download of a template for file transfer manifests, and the support for download of node pdfs in landscape orientation. To view official release notes follow this $$[Link](https://github.com/CBIIT/bento-icdc-frontend/releases/tag/v3.39.4-992)$$" 
+      the support for download of controlled vocabularies in machine-readable TSV and JSON formats, the support for download of a template for file transfer manifests, and the support for download of node pdfs in landscape orientation. To view official release notes copy this link into your browser: https://github.com/CBIIT/bento-icdc-frontend/releases/tag/v3.39.4-992
     label: Software Development
     blurb: Software Release Update
   - paragraph: >-
-      "The ICDC team was featured in the October blog from the Center for Biomedical Infromatics & Information Technology in an article titled, A Tail-Wagging Good Time-Working on the Integrated Canine Data Commons. To read the full article, follow this $$[Link](https://datascience.cancer.gov/news-events/blog/tail-wagging-good-time-working-integrated-canine-data-commons)$$" 
+      "The ICDC team was featured in the October blog from the Center for Biomedical Infromatics & Information Technology in an article titled, "A Tail-Wagging Good Time-Working on the Integrated Canine Data Commons". To read the full article, copy this link into your browser window: https://datascience.cancer.gov/news-events/blog/tail-wagging-good-time-working-integrated-canine-data-commons 
     blurb: Meet the ICDC team
     label: Meet the ICDC team
   - paragraph: >-
-      "Submit a photo of your dog to be featured in the ICDC image gallery and join the ICDC pack in the battle against cancer. Upload photos $$[here] (https://nih.sharepoint.com/:f:/r/sites/NCI-CBIIT-FNL-ICDC/Shared%20Documents/ICDC%20Software%20Development/ICDC%20Pack%20Members?csf=1&web=1&e=d4jMy0)$$"
+      Submit a photo of your dog to be featured in the ICDC image gallery and join the ICDC pack in the battle against cancer. Send photos to ICDCHelpDesk@mail.nih.gov
     blurb: Join the ICDC pack
     label: Join the ICDC pack
   - paragraph: >-
-      "Data made available through the ICDC is for research purposes only. ICDC data submission and data use is governed by the Creative
-      Commons licensing terms, $$[CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/)$$"
+      Data made available through the ICDC is for research purposes only. ICDC data submission and data use is governed by the Creative
+      Commons licensing terms, https://creativecommons.org/licenses/by/4.0/
     blurb: ICDC Data Use Guidelines
     label: ICDC leverages CC-BY 4.0 licensing terms


### PR DESCRIPTION
Hyperlinks are not currently supported in the newsView component. Removing these references until we can implment.