### PR TITLE
Update ICDC Spotlight to test ICDC-2892

### DIFF
--- a/landingView.yaml
+++ b/landingView.yaml
@@ -83,15 +83,11 @@
       value: 'icdc'
       icon: 'https://github.com/CBIIT/datacommons-assets/blob/main/icdc/images/png/Button.Spotlight.Active.png?raw=true'
       content:
-        # callToActionTitle: 'Spotlight: Trial cancer treatments for dogs could also lead to breakthroughs for humans'
-        # callToActionDescription: "Featured on 60 minutes with Anderson Cooper."
-        # callToActionButtonText: 'VIEW THE VIDEO'
-        # externalLink: true
-        # callToActionLink: 'https://www.cbsnews.com/news/dog-cancer-trials-comparative-oncology-60-minutes-2022-11-27/'
-        callToActionTitle: 'Spotlight: New Canine Urothelial Carcinoma study now available'
-        callToActionDescription: "Featured in EACR's  Top 10 Cancer Research  publications."
-        callToActionButtonText: 'VIEW THE STUDY'
-        callToActionLink: '/study/UBC01'
+        callToActionTitle: 'Spotlight: Trial cancer treatments for dogs could also lead to breakthroughs for humans'
+        callToActionDescription: "Featured on 60 minutes with Anderson Cooper."
+        callToActionButtonText: 'VIEW THE VIDEO'
+        externalLink: true
+        callToActionLink: 'https://www.cbsnews.com/news/dog-cancer-trials-comparative-oncology-60-minutes-2022-11-27/'
         image: 'https://github.com/CBIIT/datacommons-assets/blob/main/icdc/images/png/Spotlight_Studies.png?raw=true'
         template: 'imageWithCaption'
         twitter:
@@ -99,12 +95,9 @@
         youtube:
           url: 'https://www.youtube.com/watch?v=bIWaMKZ9pl4'
         imageWithCaption:
-          # img: 'https://github.com/CBIIT/bento-icdc-static-content/blob/develop/images/landing/60-minutes.png?raw=true'
-          # alt: 'ICDC researchers featured on 60 minutes'
-          # caption: 'NIH researchers discuss canine comparative oncology with Anderson Cooper.'
-          img: 'https://github.com/CBIIT/bento-icdc-static-content/blob/develop/images/landing/EACR_wide_image.png?raw=true'
-          alt: 'UBC01 featured in EACR'
-          caption: 'Dr. Debbie Knapp and team continue to fight against canine urothelial carcinomas.'
+          img: 'https://github.com/CBIIT/bento-icdc-static-content/blob/develop/images/landing/60-minutes.png?raw=true'
+          alt: 'ICDC researchers featured on 60 minutes'
+          caption: 'NIH researchers discuss canine comparative oncology with Anderson Cooper.'
         noCaptionImage:
           img: 'https://github.com/CBIIT/datacommons-assets/blob/main/icdc/images/jpgs/DogAtVet.jpg?raw=true'
           alt: 'Dog at vet'


### PR DESCRIPTION
Update the ICDC Spotlight to include 60 min segment and embed external link in the button so that clicking on "View Video" opens the external link to the actual 60 minutes recording. Although, this button functionality is not yet supported on prod, updating the .yaml file will allow testing of the button on Dev and QA.