### PR TITLE
add-line-break

### DIFF
--- a/aboutPagesContent.yaml
+++ b/aboutPagesContent.yaml
@@ -272,7 +272,7 @@
                 - "Amy LeBlanc"
                 - Member
                 - NIH/NCI/CCR/COP
-
+-
 page: /BPSC
   title: Best Practices Subcommittee 
   primaryContentImage: 'https://raw.githubusercontent.com/CBIIT/datacommons-assets/main/icdc/aboutPages/Photo-About_BPSC.jpeg'


### PR DESCRIPTION
Adds a line break to the AboutPagesContent.yaml file to resolve a yaml-based error.